### PR TITLE
Changes style-types order.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('extension.new-component', async (file) => {
 
-        let filePath = file && (file.path || file.fsPath);
+        let filePath = file && (file.fsPath || file.path);
 
         if (!filePath) {
             // Show file dialog

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('extension.new-component', async (file) => {
 
-        let filePath = file && file.path;
+        let filePath = file && file.fsPath;
 
         if (!filePath) {
             // Show file dialog

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,14 +6,14 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 const styleTypes = [{
+    name: 'SCSS',
+    ext: 'scss',
+}, {
     name: 'LESS',
     ext: 'less',
 }, {
     name: 'SASS',
     ext: 'sass',
-}, {
-    name: 'SCSS',
-    ext: 'scss',
 }, {
     name: 'CSS',
     ext: 'css',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let disposable = vscode.commands.registerCommand('extension.new-component', async (file) => {
 
-        let filePath = file && file.fsPath;
+        let filePath = file && (file.path || file.fsPath);
 
         if (!filePath) {
             // Show file dialog


### PR DESCRIPTION
This is a minor thing but saves (probably) two clicks each time a component is created.

I rearranged the order of preprocessors to reflect what is most commonly used, both within Ueno and out in the world (based on GitHub).

Look, this makes much more sense. 😉
![screen shot 2017-10-19 at 01 36 10](https://user-images.githubusercontent.com/7573694/31750445-aa1c19d6-b46f-11e7-80ba-20b806fb14fa.png)
